### PR TITLE
Instruction update for adding Android assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Including image assets in your app makes it look better and feel more polished. 
 
 ### Android assets
 
-On Android you need to add a splash screen and launch icon. To use the raywenderlich.com assets for these, replace the contents of your project's **android/app/src/main/res** folder with the contents of the **android_assets/res** folder in this repository. Then open **AndroidManifest.xml** in **android/app/src/main**. Locate and delete the `<meta-data>`:
+On Android you need to add a splash screen and launch icon. To use the raywenderlich.com assets for these, replace the contents of your project's **android/app/src/main/res** folder with the contents of the **android_assets/res** folder in this repository. Then open **AndroidManifest.xml** in **android/app/src/main**. Locate and delete the `<meta-data>` subelement:
 
 ```
 <!-- Specifies an Android theme to apply to this Activity as soon as
@@ -97,7 +97,7 @@ On Android you need to add a splash screen and launch icon. To use the raywender
   />
 ```
 
-This will get rid of the error `AAPT: error: resource style/NormalTheme not found` when building the android app.
+This will get rid of the error `AAPT: error: resource style/NormalTheme not found` when building the android app. Since the repository version of file **styles.xml** does not contain the style `NormalTheme`.
 
 ### iOS assets
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,20 @@ Including image assets in your app makes it look better and feel more polished. 
 
 ### Android assets
 
-On Android you need to add a splash screen and launch icon. To use the raywenderlich.com assets for these, replace the contents of your project's **android/app/src/main/res** folder with the contents of the **android_assets/res** folder in this repository.
+On Android you need to add a splash screen and launch icon. To use the raywenderlich.com assets for these, replace the contents of your project's **android/app/src/main/res** folder with the contents of the **android_assets/res** folder in this repository. Then open **AndroidManifest.xml** in **android/app/src/main**. Locate and delete the `<meta-data>`:
+
+```
+<!-- Specifies an Android theme to apply to this Activity as soon as
+     the Android process has started. This theme is visible to the user
+     while the Flutter UI initializes. After that, this theme continues
+     to determine the Window background behind the Flutter UI. -->
+<meta-data
+  android:name="io.flutter.embedding.android.NormalTheme"
+  android:resource="@style/NormalTheme"
+  />
+```
+
+This will get rid of the error `AAPT: error: resource style/NormalTheme not found` when building the android app.
 
 ### iOS assets
 


### PR DESCRIPTION
@rwenderlich @bkayfitz ,
I made an update in the instructions for adding Android assets in our Flutter sample project.

The current instructions for adding android assets does not include deleting the `<meta-data>` which points to `NormalTheme` in android **style.xml**. Since our version of android assets does not contain this style. It generates an error when building the android app: `AAPT: error: resource style/NormalTheme not found`.

While I agree that this issue can be resolved easily by removing the above mentioned `<meta-data>` when testing the app. But having instructions to do the same can be beneficial.