### PR TITLE
Upgrade project to use flutter_lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,69 +1,64 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options
+#
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
 analyzer:
-  exclude: 
+  exclude:
     - build/**
-    - lib/**.g.dart  
+    - lib/**.g.dart
+    
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
 
   errors:
-    missing_return: error
-    dead_code: error
     always_declare_return_types: error
     avoid_web_libraries_in_flutter: error
-    missing_required_param: error
-    file_names: error
     camel_case_types: error
+    dead_code: error
     empty_statements: error
+    file_names: error
     iterable_contains_unrelated_type: error
     list_remove_unrelated_type: error
+    missing_required_param: error
+    missing_return: error
     no_duplicate_case_values: error
+    prefer_single_quotes: error
     unrelated_type_equality_checks: error
 
     #This is added as an error to make viewing code on the web easier
     lines_longer_than_80_chars: error
-    prefer_single_quotes: error
 
 linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at
+  # https://dart-lang.github.io/linter/lints/index.html.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
   rules:
     - always_declare_return_types
-    - always_require_non_null_named_parameters
-    - annotate_overrides
     - avoid_annotating_with_dynamic
     - avoid_bool_literals_in_conditional_expressions
-    - avoid_empty_else
-    - avoid_unnecessary_containers
-    - avoid_web_libraries_in_flutter
-    - await_only_futures
-    - camel_case_types
     - cancel_subscriptions
     - close_sinks
-    - empty_statements
-    - file_names
-    - hash_and_equals
-    - iterable_contains_unrelated_type
     - lines_longer_than_80_chars
-    - list_remove_unrelated_type
-    - no_duplicate_case_values
-    - no_logic_in_create_state
     - omit_local_variable_types
     - only_throw_errors
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
-    - prefer_if_null_operators
-    - prefer_null_aware_operators
     - prefer_relative_imports
     - prefer_single_quotes
-    - prefer_void_to_null
-    - sized_box_for_whitespace
     - unnecessary_await_in_return
-    - unnecessary_const
-    - unnecessary_new
     - unnecessary_statements
-    - unnecessary_this
-    - unrelated_type_equality_checks
-    - use_key_in_widget_constructors

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Upgraded the project to use the flutter_lints package.

This PR addresses issue #4 

- Added flutter_lints package to pubspec.yaml
- Removed redundant lint rules from analysis_options.yaml
- Reorder lint errors to be in alphabetical order
- Added comments to make analyzer intent more understandable
  - Preserved lint URL links for easy access to lint documentation