### PR TITLE
Updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Kodeco LLC
+Copyright (c) 2023 Kodeco Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Flutter sample project
 
-This repository is a mini-tutorial to help you create the sample app for your tutorial on kodeco.com. The repository here includes the resources you'll need to make your app look good wherever your readers build the app.
+This repository is a mini-tutorial to help you create the sample app for your tutorial on Kodeco. The repository here includes the resources you'll need to make your app look good wherever your readers build the app.
 
 ## Sample project requirements
 
-All projects for kodeco.com Flutter tutorials should include the following items:
+All projects for Kodeco Flutter tutorials should include the following items:
 
-- com.kodeco base package name (Android, iOS)
+- com.yourcompany base package name (Android, iOS)
 - Kodeco license
 - Flutter team linting rules
 - A clean **pubspec.yaml** file
@@ -31,23 +31,23 @@ flutter upgrade
 
 ### Set the base package name
 
-Next create a Flutter project using the base package name for **kodeco.com** in reverse notation. 
+Next create a Flutter project using the base package name for **yourcompany.com** in reverse notation. 
 
 ```
-flutter create --org com.kodeco appname
+flutter create --org com.yourcompany appname
 ```
 
 Replace `appname` with your project name. This is used for both the Android package name and the iOS bundle identifier.
 
 ### Add the Kodeco license
 
-The guides require adding the license to the top of each code file, but many developers expect to find a file called **LICENSE** in the root of the project also. So create that file. You can find the [text for the file in this repository](https://github.com/raywenderlich/flutter-sample-project/blob/master/LICENSE). Change the date to the current year if needed.
+The guides require adding the license to the top of each code file, but many developers expect to find a file called **LICENSE** in the root of the project also. So create that file. You can find the [text for the file in this repository](https://github.com/kodecocodes/flutter-sample-project/blob/master/LICENSE). Change the date to the current year if needed.
 
 ### Set up linting rules
 
 Adding linting rules will help you to follow the Flutter team coding style and just write better code in general.
 
-Add a file named **analysis_options.yaml** to the root of your project. Paste in the [Flutter Team linting rules](https://github.com/raywenderlich/flutter-sample-project/blob/master/analysis_options.yaml), which you can find in the root of this repository.
+Add a file named **analysis_options.yaml** to the root of your project. Paste in the [Flutter Team linting rules](https://github.com/kodecocodes/flutter-sample-project/blob/master/analysis_options.yaml), which you can find in the root of this repository.
 
 These linting rules will let your IDE give you warnings or errors if you aren't following the Flutter Team's coding style. This also means that you should fix all of the IDE warnings and errors before you submit your sample app.
 
@@ -63,9 +63,9 @@ There is a sample **pubspec.yaml** file in the root of this repository for your 
 
 ### Use .gitignore
 
-When you create a new Flutter project it comes with a good `.gitignore` file. Go with what's in there. Also consider this a good list of things not to include when you upload your project to kodeco.com. 
+When you create a new Flutter project it comes with a good `.gitignore` file. Go with what's in there. Also consider this a good list of things not to include when you upload your project to Kodeco. 
 
-**Hint**: If you develop your project with GitHub, all you have to do is download it from GitHub before uploading it to kodeco.com. This is an easy way to ensure that there are no unnecessary files in the project.
+**Hint**: If you develop your project with GitHub, all you have to do is download it from GitHub before uploading it to Kodeco. This is an easy way to ensure that there are no unnecessary files in the project.
 
 ### Remove unused folders
 
@@ -73,19 +73,19 @@ If your project doesn't include any tests, then remove the **test** folder. The 
 
 ## Image assets
 
-Including image assets in your app makes it look better and feel more polished. You can either create your own or use the standard kodeco.com assets.
+Including image assets in your app makes it look better and feel more polished. You can either create your own or use the standard Kodeco assets.
 
 ### Android assets
 
-On Android you need to add a splash screen and launch icon. To use the kodeco.com assets for these, replace the contents of your project's **android/app/src/main/res** folder with the contents of the **android_assets/res** folder in this repository.
+On Android you need to add a splash screen and launch icon. To use the Kodeco assets for these, replace the contents of your project's **android/app/src/main/res** folder with the contents of the **android_assets/res** folder in this repository.
 
 ### iOS assets
 
-You also need to add an iOS splash screen and launch icon. To use the standard kodeco.com image assets, replace the contents of your project's **ios/Runner/Assets.xcassets** folder with the contents of the **ios_assets/Assets.xcassets** folder in this repository.
+You also need to add an iOS splash screen and launch icon. To use the standard Kodeco image assets, replace the contents of your project's **ios/Runner/Assets.xcassets** folder with the contents of the **ios_assets/Assets.xcassets** folder in this repository.
 
 ### Web assets
 
-You should also add a favicon and other asset images for the web. To use the standard kodeco.com asset images, go to your project's **web** folder and replace **favicon.png** and the contents of the **icons** folder with the image assets found in the **web_assets** folder in this repository.
+You should also add a favicon and other asset images for the web. To use the standard Kodeco asset images, go to your project's **web** folder and replace **favicon.png** and the contents of the **icons** folder with the image assets found in the **web_assets** folder in this repository.
 
 **Note**: If your project does not support the web, then delete the entire **web** folder.
 


### PR DESCRIPTION
- Updates kodeco.com to Kodeco
- Updates bundle identifier back to `com.yourcompany` (to protect our current and future apps that now need to use `com.kodeco` — before we used razeware and the team could use raywenderlich)
- Updates license